### PR TITLE
ROX-11154: Increase metric client call timeout

### DIFF
--- a/gcp_monitoring.go
+++ b/gcp_monitoring.go
@@ -122,7 +122,7 @@ func (g *gcpMonitoring) createMetricDescriptor(family *prom2json.Family) (*metri
 		MetricDescriptor: md,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
 	return g.client.CreateMetricDescriptor(ctx, req)
@@ -180,7 +180,7 @@ func (g *gcpMonitoring) writeTimeSeriesValue(metric metric, optionLabels map[str
 		}},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
 	return g.client.CreateTimeSeries(ctx, req)


### PR DESCRIPTION
`prometheus-metric-parser` is failing with timeout(see more in JIRA) in scale tests. 

Let's try a naive approach first: let's increase the timeout to 3 minutes, and if it will not work, look further.