### PR TITLE
ROX-11154: Do not fail on single GCP error

### DIFF
--- a/common.go
+++ b/common.go
@@ -134,12 +134,17 @@ func (m metricMap) writeToGoogleCloudMonitoring(keys []familyKey, labels map[str
 	if err != nil {
 		log.Fatalf("Cannot connect to GCP monitoring: %v\n", err)
 	}
+	errorCount := 0
 	for _, v := range m {
 		err := g.writeTimeSeriesValue(v, labels, timestamp)
 		if err != nil {
-			log.Fatal(errors.Wrap(err, "error writing metric: "+v.name))
+			log.Println(errors.Wrap(err, "error writing metric: "+v.name))
+			errorCount++
 		}
 		fmt.Print(".")
+	}
+	if len(m) < 20*errorCount {
+		log.Fatal("More than 5% of GCP requests failed. Exiting the job.")
 	}
 	fmt.Println("done")
 }


### PR DESCRIPTION
We suspect that small flakes in GCP monitoring latency result in CI builds failing sometimes.
To avoid that, we decided to stop failing on a single error to upload metric value to the GCP - rather, we would fail only if a certain percentage of requests failed.

5% seems like a good number after which it's no longer a flake we should avoid. As we continue to look into CI failures, we can re-evaluate this decision once we have more data.