### PR TITLE
fix: use csv encoding to create a csv

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/csv"
 	"fmt"
 	"io"
 	"log"
@@ -107,8 +108,17 @@ func (m metricMap) stdout(keys []familyKey) {
 }
 
 func (m metricMap) csv(keys []familyKey) {
+	w := csv.NewWriter(out)
 	for _, k := range keys {
-		fmt.Fprintf(out, "%s,%s,%g\n", k.metric, k.labels, m[k].value)
+		value := fmt.Sprintf("%g", m[k].value)
+		record := []string{k.metric, k.labels, value}
+		if err := w.Write(record); err != nil {
+			log.Fatalln("error writing record to csv:", err)
+		}
+		w.Flush()
+		if err := w.Error(); err != nil {
+			log.Fatalln("error flushing to csv:", err)
+		}
 	}
 }
 

--- a/testdata/metrics.csv
+++ b/testdata/metrics.csv
@@ -81,7 +81,7 @@ graphql_op_duration,Operation=LastScanned Resolver=ImageCVEs,0.7142033773584906
 graphql_op_duration,Operation=Pods Resolver=Root,2.2733501999999994
 graphql_op_duration,Operation=PolicyViolationEvents Resolver=Pods,1.1325613749999999
 graphql_op_duration,Operation=ProcessActivityEvents Resolver=Pods,0.899895125
-graphql_query_duration,Query=
+graphql_query_duration,"Query=
     query getPodEvents($podsQuery: String) {
         result: pods(query: $podsQuery) {
             id
@@ -101,7 +101,7 @@ graphql_query_duration,Query=
                 }
             }
         }
-    },4.701071875
+    }",4.701071875
 grpc_error,Code=Canceled,1
 grpc_last_message_size_received_bytes,Type=*central.MsgFromSensor_ClusterHealthInfo_,39
 grpc_last_message_size_received_bytes,Type=*central.MsgFromSensor_ClusterMetrics_,6


### PR DESCRIPTION
`csv` option creates invalid file when multiline values appear in labels. This PR fixes that by using stdlib csv encoder.